### PR TITLE
fix(ci): remove untrusted PR head checkout from pull_request_target [SEC-408]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "build: setup the node runtime"
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fixes [SEC-408](https://svavacapital.atlassian.net/browse/SEC-408) — a `pull_request_target` + untrusted PR-head checkout pattern in `.github/workflows/test.yml` that allowed arbitrary code execution in a privileged GitHub Actions runner. Validated internally with a PoC by @parvbajajsyfe.

The test workflow runs on `pull_request_target` with `checks: write` and access to environment secrets, then explicitly checks out `github.event.pull_request.head.sha`. Subsequent `npm ci` and `uses: ./` steps execute attacker-controlled code from the PR head.

## Fix

Remove the `ref:` input. `actions/checkout@v4` then falls back to the trusted base branch, so attacker-controlled `package.json` postinstall hooks and local-action implementations never execute inside the privileged runner.

```diff
       uses: actions/checkout@v4
       with:
         persist-credentials: false
-        ref: ${{ github.event.pull_request.head.sha }}
```

This is the documented mitigation in the ticket.

## Consumer impact

None. The change touches only this repo's CI (`test.yml`). `action.yml`, `dist/index.js`, and existing tags (`v1.24.0`, `v2`) are unchanged. All 18 Syfe consumer repos (`infra-github-workflows`, `alfred`, `backend`, `FMS`, `mark8`, `caishen`, `api-tests`, `svava-router`, `dev-github-workflows`, `syfe-helm-values`, plus 8 `*-manifests` repos) continue to work identically with no version bump.

## Side effect

Fork PRs will now run tests against the base branch, not the PR diff — acceptable because this fork exists to host pinned tags for Syfe consumers, not to accept external contributions.

## Follow-ups (out of scope)

- Enable *Settings → Actions → Require approval for all outside collaborators* as defence-in-depth.
- Consider disabling Actions on this fork entirely.
- 33 Dependabot vulnerabilities flagged on `main` (1 critical / 11 high) — separate ticket.

## Test plan

- [ ] CI green on this PR
- [ ] Open a draft PR from a fork after merge and confirm the checkout step pulls the base ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SEC-408]: https://svavacapital.atlassian.net/browse/SEC-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ